### PR TITLE
Issue 3 mode changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,7 @@ test-log:
 
 test-minimal:
 	nvim -u ./tests/minimal.lua tests/minimal.lua
+
+REPRO=mini.comment
+test-repro:
+	nvim -u ./tests/repro_${REPRO}.lua tests/repro_${REPRO}.lua

--- a/README.md
+++ b/README.md
@@ -87,10 +87,51 @@ If the option is a boolean, number, or array, your value will overwrite the defa
 
 ### Options
 
-| Option Name | Type    | Default Valuae | Meaning                                                         |
-| ----------- | ------- | -------------- | --------------------------------------------------------------- |
-| `debug`     | boolean | `false`        | Debug mode (if enabled show notifications for multiple actions) |
-| ...         | ...     | ...            | ...                                                             |
+| Option Name      | Type    | Default Value                                          | Meaning                                                     |
+| ---------------- | ------- | ------------------------------------------------------ | ----------------------------------------------------------- |
+| `name`           | string  | `plugin_name`                                          | Name of the plugin                                          |
+| `autoinstrument` | boolean | `true`                                                 | Automatically instrument supported plugins on setup         |
+| `plugins`        | table   | `{ which_key = true, hardtime = true, keymap = true }` | Plugins to instrument                                       |
+| `debug`          | boolean | `false`                                                | Enable debug mode (more verbose logging)                    |
+| `notify`         | boolean | `false`                                                | Enable notifications                                        |
+| `very_verbose`   | boolean | `false`                                                | Enable very verbose logging                                 |
+| `included_lhs`   | table   | `{}`                                                   | List of left-hand side (LHS) keymaps to include in stats    |
+| `excluded_rhs`   | table   | `{}`                                                   | List of right-hand side (RHS) keymaps to exclude from stats |
+| `include_rhs`    | boolean | `false`                                                | Include right-hand side (RHS) keymaps in stats              |
+
+Note: The `debug`, `notify`, and `very_verbose` options can also be set via environment variables.
+
+## Contributing
+
+When reporting issues or contributing to the project, it's helpful to create a minimal reproduction of the problem. This makes it easier for maintainers to understand and resolve the issue. Here's how you can create a `repro.lua` file:
+
+1. Create a new file named `repro.lua` in the root of the project.
+2. Add the following content to the file:
+
+```lua
+vim.env.LAZY_STDPATH = ".repro"
+load(vim.fn.system("curl -s https://raw.githubusercontent.com/folke/lazy.nvim/main/bootstrap.lua"))()
+
+require("lazy.minit").repro({
+  spec = {
+    "gmatheu/keymap-stats.nvim",
+    -- Add any other plugins that might be relevant to the issue
+  },
+})
+
+-- Add any additional configuration or steps to reproduce the issue
+
+```
+
+3. Run the repro file with:
+
+```
+nvim -u repro.lua
+```
+
+This will create a minimal Neovim environment with keymap-stats.nvim and any other necessary plugins installed. You can then add the steps to reproduce the issue in the repro file.
+
+When submitting an issue, please include the contents of your `repro.lua` file and any additional steps needed to reproduce the problem.
 
 ## References
 

--- a/lua/keymap-stats/init.lua
+++ b/lua/keymap-stats/init.lua
@@ -30,14 +30,23 @@ local function get_env_var(name)
 end
 
 local defaults = {
+  -- Name of the plugin
   name = plugin_name,
+  -- Automatically instrument supported plugins on setup
   autoinstrument = true,
+  -- Plugins to instrument
   plugins = { which_key = true, hardtime = true, keymap = true },
+  -- Enable debug mode (more verbose logging)
   debug = false or get_env_var("debug"),
+  -- Enable notifications
   notify = false or get_env_var("notify"),
+  -- Enable very verbose logging
   very_verbose = false or get_env_var("very_verbose"),
+  -- List of left-hand side (LHS) keymaps to include in stats
   included_lhs = {},
+  -- List of right-hand side (RHS) keymaps to exclude from stats
   excluded_rhs = {},
+  -- Include right-hand side (RHS) keymaps in stats
   include_rhs = false,
 }
 --

--- a/lua/keymap-stats/init.lua
+++ b/lua/keymap-stats/init.lua
@@ -65,6 +65,27 @@ local function config(opts)
 end
 -- end:options.lua }}}
 
+local function instrument_mode_switch(debug)
+  vim.api.nvim_create_autocmd("ModeChanged", {
+    pattern = "*:*",
+    callback = function()
+      local current_mode = vim.fn.mode()
+      local visual_mode = vim.fn.visualmode()
+      local current_state = vim.fn.state()
+      log.info(
+        "Mode changed: " .. "mode:" .. current_mode .. ", visual_mode:" .. visual_mode .. ", state:" .. current_state
+      )
+      if debug then
+        vim.notify(
+          "Mode changed: " .. current_mode .. visual_mode .. state,
+          vim.log.levels.DEBUG,
+          { title = plugin_name }
+        )
+      end
+    end,
+  })
+end
+
 function M.setup(opts)
   config(opts)
 
@@ -86,6 +107,7 @@ function M.setup(opts)
     end
   end
   if not instrumented and M.options.autoinstrument then
+    instrument_mode_switch(M.options.debug)
     try_instrument(M.options.plugins.which_key, require("keymap-stats.plugins.which-key"), "which-key")
     try_instrument(M.options.plugins.keymap, require("keymap-stats.plugins.keymap"), "keymap")
     try_instrument(M.options.plugins.hardtime, require("keymap-stats.plugins.hardtime"), "hardtime")

--- a/tests/busted.lua
+++ b/tests/busted.lua
@@ -81,15 +81,31 @@ require("lazy.minit").busted({
       },
     },
     {
+      "m4xshen/hardtime.nvim",
+      opts = {},
+      priority = 900,
+      enabled = true,
+      -- lazy = true,
+      event = "VeryLazy",
+      setup = function(opts)
+        require("hardtime").setup(opts)
+        require("hardtime").enable()
+        vim.notify("Hardtime enabled")
+      end,
+    },
+    {
       dir = vim.uv.cwd(),
+      priority = 1000,
       opts = {
         autoinstrument = true,
-        plugins = { which_key = false, hardtime = false, keymap = true },
+        plugins = { which_key = true, hardtime = false, keymap = true },
         debug = true,
         notify = true,
+        very_verbose = true,
         include_rhs = false,
       },
       event = "VeryLazy",
+      -- lazy = false,
       dependencies = {
         { "MunifTanjim/nui.nvim" },
         { "gmatheu/keymap-amend.nvim" },

--- a/tests/recordings/repro_1.mkv
+++ b/tests/recordings/repro_1.mkv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba068d711a724b88404e81ce7a1cc399aa1c98fc471e32c5408db5a828f44094
+size 1323468

--- a/tests/repro_1_mini.comment.lua
+++ b/tests/repro_1_mini.comment.lua
@@ -1,0 +1,36 @@
+-- Repro for: https://github.com/gmatheu/keymap-stats.nvim/issues/1
+vim.env.LAZY_STDPATH = ".tests"
+load(vim.fn.system("curl -s https://raw.githubusercontent.com/folke/lazy.nvim/main/bootstrap.lua"))()
+
+vim.opt.rtp:prepend(".")
+
+vim.g.mapleader = ","
+vim.g.maplocalleader = " "
+-- Enable number and relative number
+vim.opt.number = true
+vim.opt.relativenumber = true
+
+vim.keymap.set("n", "<Leader>,", "<cmd> :e#<CR>", { desc = "Switch Last buffer" })
+
+-- Setup lazy.nvim
+require("lazy.minit").repro({
+  spec = {
+    { "echasnovski/mini.comment", version = "*" },
+    {
+      dir = vim.uv.cwd(),
+      opts = {
+        autoinstrument = true,
+        plugins = { which_key = false, hardtime = false, keymap = true },
+        debug = false,
+        very_verbose = false,
+        notify = true,
+        include_rhs = false,
+      },
+      event = "VeryLazy",
+      dependencies = {
+        { "MunifTanjim/nui.nvim" },
+        { "anuvyklack/keymap-amend.nvim" },
+      },
+    },
+  },
+})

--- a/tests/repro_2_expected_lua_str_termcodes.lua
+++ b/tests/repro_2_expected_lua_str_termcodes.lua
@@ -1,0 +1,52 @@
+-- Repro for: https://github.com/gmatheu/keymap-stats.nvim/issues/1
+vim.env.LAZY_STDPATH = ".tests"
+load(vim.fn.system("curl -s https://raw.githubusercontent.com/folke/lazy.nvim/main/bootstrap.lua"))()
+
+vim.opt.rtp:prepend(".")
+
+vim.g.mapleader = ","
+vim.g.maplocalleader = " "
+-- Enable number and relative number
+vim.opt.number = true
+vim.opt.relativenumber = true
+
+vim.keymap.set("n", "<Leader>,", "<cmd> :e#<CR>", { desc = "Switch Last buffer" })
+vim.keymap.set("n", "<Leader>ss", "<cmd>KeymapStats session<CR>", { desc = "Shor current session stats" })
+
+-- Setup lazy.nvim
+require("lazy.minit").repro({
+  spec = {
+    {
+      "folke/snacks.nvim",
+      version = "*",
+      opts = {
+        notifier = { enabled = true },
+      },
+      keys = {
+        {
+          "<LocalLeader>c",
+          function()
+            vim.notify("Test action")
+          end,
+          mode = { "n", "v" },
+        },
+      },
+    },
+    {
+      dir = vim.uv.cwd(),
+      opts = {
+        autoinstrument = true,
+        plugins = { which_key = false, hardtime = false, keymap = true },
+        debug = false,
+        very_verbose = false,
+        notify = true,
+        include_rhs = false,
+      },
+      event = "VeryLazy",
+      dependencies = {
+        { "MunifTanjim/nui.nvim" },
+        { "anuvyklack/keymap-amend.nvim" },
+      },
+    },
+  },
+})

--- a/tests/repro_2_expected_lua_str_termcodes.lua
+++ b/tests/repro_2_expected_lua_str_termcodes.lua
@@ -9,9 +9,10 @@ vim.g.maplocalleader = " "
 -- Enable number and relative number
 vim.opt.number = true
 vim.opt.relativenumber = true
+vim.g.nomore = true
 
 vim.keymap.set("n", "<Leader>,", "<cmd> :e#<CR>", { desc = "Switch Last buffer" })
-vim.keymap.set("n", "<Leader>ss", "<cmd>KeymapStats session<CR>", { desc = "Shor current session stats" })
+vim.keymap.set("n", "<Leader>ss", "<cmd>KeymapStats session<CR>", { desc = "Show current session stats" })
 
 -- Setup lazy.nvim
 require("lazy.minit").repro({
@@ -19,6 +20,7 @@ require("lazy.minit").repro({
     {
       "folke/snacks.nvim",
       version = "*",
+      lazy = true,
       opts = {
         notifier = { enabled = true },
       },
@@ -29,6 +31,15 @@ require("lazy.minit").repro({
             vim.notify("Test action")
           end,
           mode = { "n", "v" },
+          desc = "DESC LOCAL LEADER",
+        },
+        {
+          "<Leader>c",
+          function()
+            vim.notify("Test action")
+          end,
+          mode = { "n", "v" },
+          desc = "DESC LEADER",
         },
       },
     },
@@ -37,16 +48,59 @@ require("lazy.minit").repro({
       opts = {
         autoinstrument = true,
         plugins = { which_key = false, hardtime = false, keymap = true },
-        debug = false,
-        very_verbose = false,
+        debug = true,
+        very_verbose = true,
         notify = true,
         include_rhs = false,
       },
       event = "VeryLazy",
       dependencies = {
         { "MunifTanjim/nui.nvim" },
-        { "anuvyklack/keymap-amend.nvim" },
+        { "gmatheu/keymap-amend.nvim" },
       },
     },
   },
+})
+
+local lazyState = {
+  count = 0,
+  veryLazyTriggered = false,
+  veryLazyCount = 0,
+}
+vim.api.nvim_create_autocmd("User", {
+  pattern = "LazyDone",
+  callback = function()
+    vim.notify("LazyDone")
+  end,
+})
+vim.api.nvim_create_autocmd("User", {
+  pattern = "LazyVimStarted",
+  callback = function()
+    vim.notify("LazyVimStarted")
+  end,
+})
+
+vim.api.nvim_create_autocmd("User", {
+  pattern = "VeryLazy",
+  callback = function()
+    vim.notify("Very Lazy")
+    lazyState.veryLazyTriggered = true
+  end,
+})
+vim.api.nvim_create_autocmd("User", {
+  pattern = "LazyLoad",
+  callback = function(args)
+    lazyState.count = lazyState.count + 1
+    if lazyState.veryLazyTriggered then
+      lazyState.veryLazyCount = lazyState.veryLazyCount + 1
+      vim.notify(
+        "Plugin loaded (" .. lazyState.veryLazyCount .. "/" .. lazyState.count .. "): " .. vim.inspect(args.data)
+      )
+      local plugin = require("lazy.core.config").plugins[args.data]
+      vim.notify("Plugin: " .. vim.inspect(plugin._.handlers.keys))
+      require("keymap-stats.plugins.keymap").setup()
+    else
+      vim.notify("Plugin loaded (" .. lazyState.count .. "): " .. vim.inspect(args.data))
+    end
+  end,
 })


### PR DESCRIPTION
Logs using info from vim.fn's:
* mode()
* state()
* visual_mode()

Log looks like

```
``[INFO][2025-04-10T12:32:01][...stronvim/dev/keymap-stats.nvim/lua/keymap-stats/init.lua:75] Mode changed: mode:i, visual_mode:V, state:xS
[INFO][2025-04-10T12:32:03][...stronvim/dev/keymap-stats.nvim/lua/keymap-stats/init.lua:75] Mode changed: mode:n, visual_mode:V, state:xS
[INFO][2025-04-10T12:32:05][...stronvim/dev/keymap-stats.nvim/lua/keymap-stats/init.lua:75] Mode changed: mode:n, visual_mode:V, state:oxS
[INFO][2025-04-10T12:32:05][...stronvim/dev/keymap-stats.nvim/lua/keymap-stats/init.lua:75] Mode changed: mode:n, visual_mode:V, state:xS
[INFO][2025-04-10T12:32:06][...stronvim/dev/keymap-stats.nvim/lua/keymap-stats/init.lua:75] Mode changed: mode:c, visual_mode:V, state:xS
[INFO][2025-04-10T12:32:06][...stronvim/dev/keymap-stats.nvim/lua/keymap-stats/init.lua:75] Mode changed: mode:n, visual_mode:V, state:xS
```


Fixes #3 

